### PR TITLE
AddressCreate

### DIFF
--- a/src/main/java/com/example/restservice/Address/controllers/AddressController.java
+++ b/src/main/java/com/example/restservice/Address/controllers/AddressController.java
@@ -1,0 +1,33 @@
+package com.example.restservice.Address.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.example.restservice.Users.dto.*;
+import com.example.restservice.Users.usecase.*;
+import com.example.restservice.Address.dto.CreateAddressRequestDTO;
+import com.example.restservice.Address.dto.CreateAddressResponseDTO;
+import com.example.restservice.Address.usecases.CreateAddressUsecase;
+import com.example.restservice.Users.domain.PageQuery;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/addresses")
+public class AddressController {
+
+  private final CreateAddressUsecase createAddressUsecase;
+
+  public AddressController(CreateAddressUsecase createAddressUsecase) {
+    this.createAddressUsecase = createAddressUsecase;
+  }
+
+  @PostMapping
+  public ResponseEntity<CreateAddressResponseDTO> create(
+      @Valid @RequestBody CreateAddressRequestDTO requestModel) {
+
+    CreateAddressResponseDTO response = createAddressUsecase.execute(requestModel);
+
+    return ResponseEntity.ok(response);
+  }
+ }

--- a/src/main/java/com/example/restservice/Address/domain/DatabaseAddressRepository.java
+++ b/src/main/java/com/example/restservice/Address/domain/DatabaseAddressRepository.java
@@ -1,0 +1,5 @@
+package com.example.restservice.Address.domain;
+
+public interface DatabaseAddressRepository {
+  public Address save(Address address);  
+}

--- a/src/main/java/com/example/restservice/Address/dto/CreateAddressRequestDTO.java
+++ b/src/main/java/com/example/restservice/Address/dto/CreateAddressRequestDTO.java
@@ -1,0 +1,51 @@
+package com.example.restservice.Address.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateAddressRequestDTO(
+    @NotNull(message = "User ID is required")
+    Long userId,
+
+    @NotBlank(message = "Full name is required")
+    @Size(max = 100, message = "Full name must not exceed 100 characters")
+    String fullName,
+
+    @NotBlank(message = "Phone number is required")
+    @Size(max = 10, message = "Phone number must not exceed 10 characters")
+    String phoneNumber,
+
+    @NotBlank(message = "Address line 1 is required")
+    @Size(max = 100, message = "Address line 1 must not exceed 100 characters")
+    String addressLine1,
+
+    @Size(max = 100, message = "Address line 2 must not exceed 100 characters")
+    String addressLine2,
+
+    @NotBlank(message = "Sub-district is required")
+    @Size(max = 100, message = "Sub-district must not exceed 100 characters")
+    String subDistrict,
+
+    @NotBlank(message = "District is required")
+    @Size(max = 100, message = "District must not exceed 100 characters")
+    String district,
+
+    @NotBlank(message = "Province is required")
+    @Size(max = 100, message = "Province must not exceed 100 characters")
+    String province,
+
+    @NotBlank(message = "Postal code is required")
+    @Size(max = 10, message = "Postal code must not exceed 10 characters")
+    String postalCode,
+
+    @NotBlank(message = "Country is required")
+    @Size(max = 100, message = "Country must not exceed 100 characters")
+    String country,
+
+    @Size(max = 100, message = "Label must not exceed 100 characters")
+    String label,
+
+    Boolean isDefault
+) {
+}

--- a/src/main/java/com/example/restservice/Address/dto/CreateAddressResponseDTO.java
+++ b/src/main/java/com/example/restservice/Address/dto/CreateAddressResponseDTO.java
@@ -1,0 +1,5 @@
+package com.example.restservice.Address.dto;
+
+public record CreateAddressResponseDTO(String message){
+
+}

--- a/src/main/java/com/example/restservice/Address/models/AddressModel.java
+++ b/src/main/java/com/example/restservice/Address/models/AddressModel.java
@@ -1,0 +1,126 @@
+package com.example.restservice.Address.models;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import com.example.restservice.Address.domain.Address;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "addresses") // กำหนดชื่อตาราง (ปรับให้ตรงกับฐานข้อมูลจริงของคุณได้)
+public class AddressModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(length = 100, nullable = false)
+    private String fullName;
+
+    @Column(length = 10, nullable = false)
+    private String phoneNumber;
+
+    @Column(length = 100, nullable = false)
+    private String addressLine1;
+
+    @Column(length = 100)
+    private String addressLine2;
+
+    @Column(length = 100, nullable = false)
+    private String subDistrict;
+
+    @Column(length = 100, nullable = false) // ปรับ District เป็นตัวพิมพ์เล็ก
+    private String district;
+
+    @Column(length = 100, nullable = false)
+    private String province;
+
+    @Column( length = 10, nullable = false)
+    private String postalCode;
+
+    @Column( length = 100, nullable = false)
+    private String country;
+
+    @Column(length = 100)
+    private String label;
+
+    private boolean isDefault;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    protected AddressModel(){} 
+    
+    public Long getId() { return id; }
+    public Long getUserId() { return userId; }
+    public String getFullName() { return fullName; }
+    public String getPhoneNumber() { return phoneNumber; }
+    public String getAddressLine1() { return addressLine1; }
+    public String getAddressLine2() { return addressLine2; }
+    public String getSubDistrict() { return subDistrict; }
+    public String getDistrict() { return district; }
+    public String getProvince() { return province; }
+    public String getPostalCode() { return postalCode; }
+    public String getCountry() { return country; }
+    public String getLabel() { return label; }
+    public boolean isDefault() { return isDefault; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+
+    public Address toDomain() {
+        return Address.rehydrate(
+                this.id,
+                this.userId,
+                this.fullName,
+                this.phoneNumber,
+                this.addressLine1,
+                this.addressLine2,
+                this.subDistrict,
+                this.district,
+                this.province,
+                this.postalCode,
+                this.country,
+                this.label,
+                this.isDefault,
+                this.createdAt,
+                this.updatedAt
+        );
+    }
+
+    public static AddressModel fromDomain(Address address) {
+        if (address == null) {
+            return null;
+        }
+
+        AddressModel entity = new AddressModel();
+        
+        if (address.getId() != null) {
+            entity.id = address.getId();
+        }
+        
+        entity.userId = address.getUserId();
+        entity.fullName = address.getFullName();
+        entity.phoneNumber = address.getPhoneNumber().value();
+        entity.addressLine1 = address.getAddressLine1();
+        entity.addressLine2 = address.getAddressLine2();
+        entity.subDistrict = address.getSubDistrict();
+        entity.district = address.getDistrict();
+        entity.province = address.getProvince();
+        entity.postalCode = address.getPostalCode();
+        entity.country = address.getCountry();
+        entity.label = address.getLabel();
+        entity.isDefault = address.isDefault();
+        
+
+        return entity;
+  }
+}

--- a/src/main/java/com/example/restservice/Address/repositories/DatabaseAddressRepositoryImpl.java
+++ b/src/main/java/com/example/restservice/Address/repositories/DatabaseAddressRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.example.restservice.Address.repositories;
+
+import com.example.restservice.Address.domain.Address;
+import com.example.restservice.Address.domain.DatabaseAddressRepository;
+import com.example.restservice.Address.models.AddressModel;
+
+public class DatabaseAddressRepositoryImpl implements DatabaseAddressRepository{
+  private final JpaAddressRepository jpaAddressRepository;
+
+  public DatabaseAddressRepositoryImpl(JpaAddressRepository jpaAddressRepository) {
+    this.jpaAddressRepository = jpaAddressRepository;
+  }
+  @Override
+  public Address save(Address address) {
+    AddressModel model = AddressModel.fromDomain(address);
+    AddressModel saved = jpaAddressRepository.save(model);
+    return saved.toDomain();
+  }
+ 
+}  

--- a/src/main/java/com/example/restservice/Address/repositories/JpaAddressRepository.java
+++ b/src/main/java/com/example/restservice/Address/repositories/JpaAddressRepository.java
@@ -1,0 +1,11 @@
+package com.example.restservice.Address.repositories;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.restservice.Address.models.AddressModel;
+
+public interface JpaAddressRepository
+    extends JpaRepository<AddressModel, String> {
+}

--- a/src/main/java/com/example/restservice/Address/usecases/CreateAddressUsecase.java
+++ b/src/main/java/com/example/restservice/Address/usecases/CreateAddressUsecase.java
@@ -1,0 +1,34 @@
+package com.example.restservice.Address.usecases;
+
+import com.example.restservice.Address.domain.*;
+import com.example.restservice.Address.dto.*;
+
+public class CreateAddressUsecase {
+
+  private final DatabaseAddressRepository databaseAddressRepository;
+
+  public CreateAddressUsecase(DatabaseAddressRepository databaseAddressRepository) {
+    this.databaseAddressRepository = databaseAddressRepository;
+  }  
+
+  public CreateAddressResponseDTO execute(CreateAddressRequestDTO request){
+    boolean defaultStatus= request.isDefault() != null ? request.isDefault() : false;
+
+        Address newAddress = Address.create(
+            request.userId(),
+            request.fullName(),
+            request.phoneNumber(),
+            request.addressLine1(),
+            request.addressLine2(),
+            request.subDistrict(),
+            request.district(),
+            request.province(),
+            request.postalCode(),
+            request.country(),
+            request.label(),
+            defaultStatus
+        );
+        this.databaseAddressRepository.save(newAddress); 
+        return new CreateAddressResponseDTO("Address was created");
+  }  
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the full `Address` feature slice — controller, use case, domain repository interface, JPA repository, model, and DTOs — following the same clean architecture pattern already established by the `Users` module. The structure is sound and the separation of concerns is well maintained, but there are three critical Spring bean registration issues that will prevent the application from starting, plus a validation inconsistency between the DTO and the domain layer.

**Key issues found:**
- `DatabaseAddressRepositoryImpl` is missing `@Repository` and `CreateAddressUsecase` is missing `@Service` — neither will be registered as Spring beans, causing `NoSuchBeanDefinitionException` on startup
- `JpaAddressRepository` declares the ID type as `String` instead of `Long`, mismatching `AddressModel`'s `Long` primary key and causing a `ClassCastException` at runtime
- `CreateAddressRequestDTO` constrains `phoneNumber` to `@Size(max = 10)`, but the `PhoneNumber` domain value object accepts up to 20 characters — valid international numbers will be incorrectly rejected before reaching domain logic
- `AddressController` contains unused imports from the `Users` package and returns HTTP 200 instead of the conventional 201 for resource creation

<h3>Confidence Score: 1/5</h3>

- Not safe to merge — the application will fail to start due to missing Spring annotations and a type mismatch in the JPA repository.
- Three separate issues will cause the application to fail at startup or throw runtime exceptions: missing @Repository on DatabaseAddressRepositoryImpl, missing @Service on CreateAddressUsecase, and the wrong ID type (String instead of Long) in JpaAddressRepository. Additionally, the phone number size constraint conflict will silently reject valid inputs in production.
- Pay close attention to `JpaAddressRepository.java`, `DatabaseAddressRepositoryImpl.java`, and `CreateAddressUsecase.java`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main/java/com/example/restservice/Address/repositories/JpaAddressRepository.java | Wrong ID type parameter: extends JpaRepository<AddressModel, String> but AddressModel's @Id is Long — will cause ClassCastException at runtime. |
| src/main/java/com/example/restservice/Address/repositories/DatabaseAddressRepositoryImpl.java | Missing @Repository annotation; Spring will not register this class as a bean, causing NoSuchBeanDefinitionException on startup. |
| src/main/java/com/example/restservice/Address/usecases/CreateAddressUsecase.java | Missing @Service annotation; Spring will not detect this use case as a bean, preventing AddressController from starting up. |
| src/main/java/com/example/restservice/Address/dto/CreateAddressRequestDTO.java | Phone number @Size(max=10) conflicts with PhoneNumber domain pattern allowing up to 20 characters; valid numbers will be incorrectly rejected. |
| src/main/java/com/example/restservice/Address/controllers/AddressController.java | Clean controller following separation-of-concerns pattern; has unused imports from the Users package and returns HTTP 200 instead of 201 for resource creation. |
| src/main/java/com/example/restservice/Address/models/AddressModel.java | Well-structured JPA entity with correct domain mapping; fromDomain and toDomain converters look correct. |
| src/main/java/com/example/restservice/Address/domain/DatabaseAddressRepository.java | Simple repository interface for the domain layer; correctly placed and defined. |
| src/main/java/com/example/restservice/Address/dto/CreateAddressResponseDTO.java | Minimal response DTO; looks correct for the current use case. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant AddressController
    participant CreateAddressUsecase
    participant Address (Domain)
    participant DatabaseAddressRepository
    participant DatabaseAddressRepositoryImpl
    participant JpaAddressRepository
    participant DB

    Client->>AddressController: POST /api/addresses (CreateAddressRequestDTO)
    AddressController->>AddressController: @Valid bean validation
    AddressController->>CreateAddressUsecase: execute(requestDTO)
    CreateAddressUsecase->>Address (Domain): Address.create(fields...)
    Address (Domain)->>Address (Domain): PhoneNumber.of(phoneNumber)
    Address (Domain)->>Address (Domain): validate()
    Address (Domain)-->>CreateAddressUsecase: Address domain object
    CreateAddressUsecase->>DatabaseAddressRepository: save(address)
    DatabaseAddressRepository->>DatabaseAddressRepositoryImpl: save(address)
    DatabaseAddressRepositoryImpl->>DatabaseAddressRepositoryImpl: AddressModel.fromDomain(address)
    DatabaseAddressRepositoryImpl->>JpaAddressRepository: save(AddressModel)
    JpaAddressRepository->>DB: INSERT INTO addresses
    DB-->>JpaAddressRepository: saved AddressModel
    JpaAddressRepository-->>DatabaseAddressRepositoryImpl: saved AddressModel
    DatabaseAddressRepositoryImpl->>DatabaseAddressRepositoryImpl: saved.toDomain()
    DatabaseAddressRepositoryImpl-->>CreateAddressUsecase: Address domain object
    CreateAddressUsecase-->>AddressController: CreateAddressResponseDTO("Address was created")
    AddressController-->>Client: 200 OK (should be 201 Created)
```

<sub>Last reviewed commit: e7bfb2b</sub>

> Greptile also left **6 inline comments** on this PR.

**Context used:**

- Rule used - # Code Review Rule: Separation of Concerns by Laye... ([source](https://app.greptile.com/review/custom-context?memory=71de1a33-4d13-4be4-b844-db2b9e14b831))

<!-- /greptile_comment -->