### PR TITLE
AddressDeteleImplement

### DIFF
--- a/src/main/java/com/example/restservice/Address/domain/DatabaseAddressRepository.java
+++ b/src/main/java/com/example/restservice/Address/domain/DatabaseAddressRepository.java
@@ -1,5 +1,9 @@
 package com.example.restservice.Address.domain;
 
+import java.util.Optional;
+
 public interface DatabaseAddressRepository {
-  public Address save(Address address);  
+  public Address save(Address address); 
+  Optional<Address> findById(Long id);
+  public Address delete(Address address);
 }

--- a/src/main/java/com/example/restservice/Address/dto/DeleteAddressRequestDTO.java
+++ b/src/main/java/com/example/restservice/Address/dto/DeleteAddressRequestDTO.java
@@ -1,0 +1,12 @@
+package com.example.restservice.Address.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteAddressRequestDTO(
+        @NotNull(message = "Address ID is required")
+        Long addressId,
+
+        @NotNull(message = "User ID is required")
+        Long userId
+) {
+}

--- a/src/main/java/com/example/restservice/Address/dto/DeleteAddressResponseDTO.java
+++ b/src/main/java/com/example/restservice/Address/dto/DeleteAddressResponseDTO.java
@@ -1,0 +1,5 @@
+package com.example.restservice.Address.dto;
+
+public record DeleteAddressResponseDTO(String massage){
+
+} 

--- a/src/main/java/com/example/restservice/Address/models/AddressModel.java
+++ b/src/main/java/com/example/restservice/Address/models/AddressModel.java
@@ -9,7 +9,7 @@ import com.example.restservice.Address.domain.Address;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "addresses") // กำหนดชื่อตาราง (ปรับให้ตรงกับฐานข้อมูลจริงของคุณได้)
+@Table(name = "addresses")
 public class AddressModel {
 
     @Id
@@ -34,7 +34,7 @@ public class AddressModel {
     @Column(length = 100, nullable = false)
     private String subDistrict;
 
-    @Column(length = 100, nullable = false) // ปรับ District เป็นตัวพิมพ์เล็ก
+    @Column(length = 100, nullable = false)
     private String district;
 
     @Column(length = 100, nullable = false)

--- a/src/main/java/com/example/restservice/Address/repositories/DatabaseAddressRepositoryImpl.java
+++ b/src/main/java/com/example/restservice/Address/repositories/DatabaseAddressRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.example.restservice.Address.repositories;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
 import com.example.restservice.Address.domain.Address;
@@ -19,6 +21,16 @@ public class DatabaseAddressRepositoryImpl implements DatabaseAddressRepository 
     AddressModel model = AddressModel.fromDomain(address);
     AddressModel saved = jpaAddressRepository.save(model);
     return saved.toDomain();
+  }
+  @Override
+  public Optional<Address> findById(Long id) {
+    return jpaAddressRepository.findById(id).map(AddressModel::toDomain);
+  }
+
+  @Override
+  public Address delete(Address address) {
+    jpaAddressRepository.deleteById(address.getId());   
+    return address;
   }
 
 }

--- a/src/main/java/com/example/restservice/Address/repositories/JpaAddressRepository.java
+++ b/src/main/java/com/example/restservice/Address/repositories/JpaAddressRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.example.restservice.Address.models.AddressModel;
 
 public interface JpaAddressRepository
-    extends JpaRepository<AddressModel, String> {
+    extends JpaRepository<AddressModel, Long> {
 }

--- a/src/main/java/com/example/restservice/Address/usecases/DeleteAddressUsecase.java
+++ b/src/main/java/com/example/restservice/Address/usecases/DeleteAddressUsecase.java
@@ -1,0 +1,28 @@
+package com.example.restservice.Address.usecases;
+
+import org.springframework.stereotype.Service;
+
+import com.example.restservice.Address.domain.*;
+import com.example.restservice.Address.dto.*;
+
+@Service
+public class DeleteAddressUsecase {
+
+    private final DatabaseAddressRepository databaseAddressRepository;
+
+    public DeleteAddressUsecase(DatabaseAddressRepository databaseAddressRepository) {
+        this.databaseAddressRepository = databaseAddressRepository;
+    }
+
+    public DeleteAddressResponseDTO execute(DeleteAddressRequestDTO request) {
+        Address existingAddress = this.databaseAddressRepository.findById(request.addressId())
+                .orElseThrow(() -> new RuntimeException("Address not found"));
+
+        if (!existingAddress.getUserId().equals(request.userId())) {
+            throw new RuntimeException("Unauthorized to delete this address");
+        }
+        this.databaseAddressRepository.delete(existingAddress);
+
+        return new DeleteAddressResponseDTO("Address was deleted successfully");
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the delete address feature, adding a `DeleteAddressUsecase` that verifies ownership before removing an address, along with the necessary DTOs, repository interface methods, and their implementations. The architecture correctly follows clean layering — the use case depends on the domain repository interface and not on JPA directly — and also includes an important bug fix changing `JpaRepository<AddressModel, String>` to `JpaRepository<AddressModel, Long>` to match the actual `@Id` type.

**Key changes:**
- New `DeleteAddressUsecase` performs a `findById` + ownership check before calling `delete`
- New `DeleteAddressRequestDTO` / `DeleteAddressResponseDTO` records for request/response
- `DatabaseAddressRepository` interface extended with `findById` and `delete`
- `DatabaseAddressRepositoryImpl` implements both new methods via the JPA layer
- `JpaAddressRepository` generic type corrected from `String` to `Long`

**Issues found:**
- `DeleteAddressResponseDTO` has a typo: the field is named `massage` instead of `message`, which will produce a misspelled JSON key in every API response
- `DeleteAddressUsecase` throws a bare `RuntimeException` for both the "not found" and "unauthorized" cases, making it impossible for an exception handler to map them to the correct HTTP status codes (404 vs 403)
- The `delete` method on the domain repository interface returns `Address`, but the return value is never used at the call site — the return type should be `void`

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — the `massage` typo will produce a broken API contract for all callers of the delete endpoint.
- The core logic (ownership check, delete flow, repository layering) is correct, but the misspelled field name in the response DTO is a hard API contract bug that needs fixing before merge. The bare `RuntimeException` issue is a meaningful concern for proper HTTP error handling but not a blocker by itself.
- `DeleteAddressResponseDTO.java` must be fixed for the typo; `DeleteAddressUsecase.java` should be reviewed for proper exception handling.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main/java/com/example/restservice/Address/dto/DeleteAddressResponseDTO.java | New response DTO with a typo: field `massage` should be `message`, which will surface as a misspelled JSON key in API responses. |
| src/main/java/com/example/restservice/Address/usecases/DeleteAddressUsecase.java | New use case implementing delete with ownership check; correctly follows clean architecture layering, but uses bare `RuntimeException` for both 404 and 403 scenarios, making it impossible for exception handlers to return correct HTTP status codes. |
| src/main/java/com/example/restservice/Address/domain/DatabaseAddressRepository.java | Domain repository interface extended with `findById` and `delete`; `delete` unnecessarily returns `Address` when the return value is never used. |
| src/main/java/com/example/restservice/Address/repositories/DatabaseAddressRepositoryImpl.java | Repository implementation correctly delegates `findById` and `deleteById` to the JPA layer; clean and straightforward. |
| src/main/java/com/example/restservice/Address/repositories/JpaAddressRepository.java | Fixed the generic type from `String` to `Long` to match the `@Id` field type in `AddressModel` — a necessary and correct correction. |
| src/main/java/com/example/restservice/Address/dto/DeleteAddressRequestDTO.java | New request DTO with `@NotNull` validation on both `addressId` and `userId`; clean and correct. |
| src/main/java/com/example/restservice/Address/models/AddressModel.java | Minor cleanup: removed Thai-language inline comments. No functional change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Controller
    participant DeleteAddressUsecase
    participant DatabaseAddressRepository
    participant JpaAddressRepository

    Client->>Controller: DELETE /addresses (DeleteAddressRequestDTO)
    Controller->>DeleteAddressUsecase: execute(request)
    DeleteAddressUsecase->>DatabaseAddressRepository: findById(addressId)
    DatabaseAddressRepository->>JpaAddressRepository: findById(id)
    JpaAddressRepository-->>DatabaseAddressRepository: Optional<AddressModel>
    DatabaseAddressRepository-->>DeleteAddressUsecase: Optional<Address>
    alt Address not found
        DeleteAddressUsecase-->>Controller: RuntimeException("Address not found")
    else Address found
        DeleteAddressUsecase->>DeleteAddressUsecase: check userId ownership
        alt Unauthorized
            DeleteAddressUsecase-->>Controller: RuntimeException("Unauthorized")
        else Authorized
            DeleteAddressUsecase->>DatabaseAddressRepository: delete(address)
            DatabaseAddressRepository->>JpaAddressRepository: deleteById(id)
            DeleteAddressUsecase-->>Controller: DeleteAddressResponseDTO("Address was deleted successfully")
            Controller-->>Client: 200 OK
        end
    end
```

<sub>Last reviewed commit: 8d6704d</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - # Code Review Rule: Separation of Concerns by Laye... ([source](https://app.greptile.com/review/custom-context?memory=71de1a33-4d13-4be4-b844-db2b9e14b831))

<!-- /greptile_comment -->