### PR TITLE
adddeleteinAddressController

### DIFF
--- a/src/main/java/com/example/restservice/Address/controllers/AddressController.java
+++ b/src/main/java/com/example/restservice/Address/controllers/AddressController.java
@@ -5,7 +5,10 @@ import org.springframework.web.bind.annotation.*;
 
 import com.example.restservice.Address.dto.CreateAddressRequestDTO;
 import com.example.restservice.Address.dto.CreateAddressResponseDTO;
+import com.example.restservice.Address.dto.DeleteAddressRequestDTO;
+import com.example.restservice.Address.dto.DeleteAddressResponseDTO;
 import com.example.restservice.Address.usecases.CreateAddressUsecase;
+import com.example.restservice.Address.usecases.DeleteAddressUsecase;
 
 import jakarta.validation.Valid;
 
@@ -14,9 +17,11 @@ import jakarta.validation.Valid;
 public class AddressController {
 
   private final CreateAddressUsecase createAddressUsecase;
+  private final DeleteAddressUsecase deleteAddressUsecase;
 
-  public AddressController(CreateAddressUsecase createAddressUsecase) {
+  public AddressController(CreateAddressUsecase createAddressUsecase,DeleteAddressUsecase deleteAddressUsecase) {
     this.createAddressUsecase = createAddressUsecase;
+    this.deleteAddressUsecase = deleteAddressUsecase;
   }
 
   @PostMapping
@@ -24,6 +29,14 @@ public class AddressController {
       @Valid @RequestBody CreateAddressRequestDTO requestModel) {
 
     CreateAddressResponseDTO response = createAddressUsecase.execute(requestModel);
+
+    return ResponseEntity.ok(response);
+  }
+  @DeleteMapping
+  public ResponseEntity<DeleteAddressResponseDTO> delete(
+    @Valid @RequestBody DeleteAddressRequestDTO requestModel) {
+
+    DeleteAddressResponseDTO response = deleteAddressUsecase.execute(requestModel);
 
     return ResponseEntity.ok(response);
   }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `DELETE /api/addresses` endpoint to `AddressController`, wiring up the new `DeleteAddressUsecase` and its associated DTOs. The architecture correctly follows the existing layered pattern (controller → use case → repository), which is consistent with the rest of the codebase.

However, there are two notable issues:

- **Incorrect HTTP status codes on error paths**: `DeleteAddressUsecase` throws plain `RuntimeException` for "address not found" (expected 404) and "unauthorized owner" (expected 403). The `GlobalExceptionHandler` has no handler for `RuntimeException`, so both scenarios will surface as HTTP 500 to clients. Domain-specific exceptions should be introduced and registered in the handler, mirroring the established pattern for `UserNotFoundException`.
- **Non-standard use of `@RequestBody` in a DELETE endpoint**: Resource identifiers should be passed via path variables (e.g., `/api/addresses/{addressId}`), not a request body. Some HTTP clients and intermediaries can strip bodies from DELETE requests, making this fragile.
- **Typo in related DTO**: `DeleteAddressResponseDTO` defines the field as `massage` instead of `message`. This will serialize incorrectly in the JSON response (e.g., `{"massage": "Address was deleted successfully"}`).
- **Authorization via request body**: The `userId` is trusted directly from the request body to authorize deletion. This is insecure without a proper authentication layer ensuring the caller can only supply their own ID. Consider deriving the user identity from the authenticated principal in Spring Security's `SecurityContext`.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — the delete endpoint will return HTTP 500 on expected 404/403 error paths, producing incorrect API behavior for clients.
- The RuntimeException handling gap means that two common, expected failure scenarios (address not found, unauthorized owner) both surface as HTTP 500 instead of appropriate 4xx responses. This is a functional correctness issue that would directly impact API consumers. Additionally, using a request body in DELETE and an insecure userId-in-body authorization pattern compound the concerns.
- Pay close attention to `DeleteAddressUsecase.java` (RuntimeException usage) and `DeleteAddressResponseDTO.java` (field typo `massage` → `message`), as well as the `GlobalExceptionHandler.java` which needs new exception mappings for the address domain.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main/java/com/example/restservice/Address/controllers/AddressController.java | Adds a DELETE /api/addresses endpoint. Two issues: request body used in DELETE (non-standard/fragile), and the underlying use case throws RuntimeException which is not handled by GlobalExceptionHandler, causing HTTP 500 on expected 404/403 paths. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant AddressController
    participant DeleteAddressUsecase
    participant DatabaseAddressRepository
    participant GlobalExceptionHandler

    Client->>AddressController: DELETE /api/addresses (body: addressId, userId)
    AddressController->>DeleteAddressUsecase: execute(requestModel)
    DeleteAddressUsecase->>DatabaseAddressRepository: findById(addressId)
    alt Address not found
        DatabaseAddressRepository-->>DeleteAddressUsecase: empty Optional
        DeleteAddressUsecase-->>AddressController: throws RuntimeException("Address not found")
        AddressController-->>GlobalExceptionHandler: RuntimeException (unhandled)
        GlobalExceptionHandler-->>Client: HTTP 500 ❌ (expected 404)
    else userId mismatch
        DatabaseAddressRepository-->>DeleteAddressUsecase: Address
        DeleteAddressUsecase-->>AddressController: throws RuntimeException("Unauthorized")
        AddressController-->>GlobalExceptionHandler: RuntimeException (unhandled)
        GlobalExceptionHandler-->>Client: HTTP 500 ❌ (expected 403)
    else Success
        DatabaseAddressRepository-->>DeleteAddressUsecase: Address
        DeleteAddressUsecase->>DatabaseAddressRepository: delete(address)
        DeleteAddressUsecase-->>AddressController: DeleteAddressResponseDTO
        AddressController-->>Client: HTTP 200 OK
    end
```

<sub>Last reviewed commit: a85583a</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->