### PR TITLE
addressISdefault

### DIFF
--- a/src/main/java/com/example/restservice/Address/controllers/AddressController.java
+++ b/src/main/java/com/example/restservice/Address/controllers/AddressController.java
@@ -7,8 +7,11 @@ import com.example.restservice.Address.dto.CreateAddressRequestDTO;
 import com.example.restservice.Address.dto.CreateAddressResponseDTO;
 import com.example.restservice.Address.dto.DeleteAddressRequestDTO;
 import com.example.restservice.Address.dto.DeleteAddressResponseDTO;
+import com.example.restservice.Address.dto.SetDefaultAddressRequestDTO;
+import com.example.restservice.Address.dto.SetDefaultAddressResponseDTO;
 import com.example.restservice.Address.usecases.CreateAddressUsecase;
 import com.example.restservice.Address.usecases.DeleteAddressUsecase;
+import com.example.restservice.Address.usecases.SetDefaultAddressUsecase;
 
 import jakarta.validation.Valid;
 
@@ -18,10 +21,12 @@ public class AddressController {
 
   private final CreateAddressUsecase createAddressUsecase;
   private final DeleteAddressUsecase deleteAddressUsecase;
+  private final SetDefaultAddressUsecase setDefaultAddressUsecase;
 
-  public AddressController(CreateAddressUsecase createAddressUsecase,DeleteAddressUsecase deleteAddressUsecase) {
+  public AddressController(CreateAddressUsecase createAddressUsecase,DeleteAddressUsecase deleteAddressUsecase,SetDefaultAddressUsecase setDefaultAddressUsecase) {
     this.createAddressUsecase = createAddressUsecase;
     this.deleteAddressUsecase = deleteAddressUsecase;
+    this.setDefaultAddressUsecase = setDefaultAddressUsecase;
   }
 
   @PostMapping
@@ -38,6 +43,13 @@ public class AddressController {
 
     DeleteAddressResponseDTO response = deleteAddressUsecase.execute(requestModel);
 
+    return ResponseEntity.ok(response);
+  }
+  @PatchMapping("/default")
+  public ResponseEntity<SetDefaultAddressResponseDTO> setDefault(
+      @Valid @RequestBody SetDefaultAddressRequestDTO requestModel) {
+
+    SetDefaultAddressResponseDTO response = this.setDefaultAddressUsecase.execute(requestModel);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/example/restservice/Address/domain/DatabaseAddressRepository.java
+++ b/src/main/java/com/example/restservice/Address/domain/DatabaseAddressRepository.java
@@ -9,4 +9,6 @@ public interface DatabaseAddressRepository {
   Optional<Address> findById(UUID id);
 
   public Address delete(Address address);
+
+  public void clearDefaultByUserId(UUID userId);
 }

--- a/src/main/java/com/example/restservice/Address/dto/SetDefaultAddressRequestDTO.java
+++ b/src/main/java/com/example/restservice/Address/dto/SetDefaultAddressRequestDTO.java
@@ -1,0 +1,13 @@
+package com.example.restservice.Address.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record SetDefaultAddressRequestDTO(
+    @NotNull(message = "Address ID is required")
+    UUID addressId,
+
+    @NotNull(message = "User ID is required")
+    UUID userId
+) {
+}

--- a/src/main/java/com/example/restservice/Address/dto/SetDefaultAddressResponseDTO.java
+++ b/src/main/java/com/example/restservice/Address/dto/SetDefaultAddressResponseDTO.java
@@ -1,0 +1,5 @@
+package com.example.restservice.Address.dto;
+
+public record SetDefaultAddressResponseDTO(String message){
+
+}

--- a/src/main/java/com/example/restservice/Address/repositories/DatabaseAddressRepositoryImpl.java
+++ b/src/main/java/com/example/restservice/Address/repositories/DatabaseAddressRepositoryImpl.java
@@ -35,4 +35,9 @@ public class DatabaseAddressRepositoryImpl implements DatabaseAddressRepository 
     return address;
   }
 
+  @Override
+  public void clearDefaultByUserId(UUID userId) {
+    jpaAddressRepository.clearDefaultAddressForUser(userId);
+  }
+
 }

--- a/src/main/java/com/example/restservice/Address/repositories/JpaAddressRepository.java
+++ b/src/main/java/com/example/restservice/Address/repositories/JpaAddressRepository.java
@@ -4,9 +4,14 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.example.restservice.Address.models.AddressModel;
 
 public interface JpaAddressRepository
-        extends JpaRepository<AddressModel, UUID> {
+                extends JpaRepository<AddressModel, UUID> {
+        @Modifying
+        @Query("UPDATE AddressModel a SET a.isDefault = false WHERE a.userId = :userId")
+        public void clearDefaultAddressForUser(UUID userId);
 }

--- a/src/main/java/com/example/restservice/Address/usecases/SetDefaultAddressUsecase.java
+++ b/src/main/java/com/example/restservice/Address/usecases/SetDefaultAddressUsecase.java
@@ -1,0 +1,49 @@
+package com.example.restservice.Address.usecases;
+
+import java.util.UUID;
+
+import com.example.restservice.Address.domain.Address;
+import com.example.restservice.Address.domain.DatabaseAddressRepository;
+import com.example.restservice.Address.dto.SetDefaultAddressRequestDTO;
+import com.example.restservice.Address.dto.SetDefaultAddressResponseDTO;
+
+public class SetDefaultAddressUsecase {
+
+    private final DatabaseAddressRepository repository;
+
+    public SetDefaultAddressUsecase(DatabaseAddressRepository repository) {
+        this.repository = repository;
+    }
+
+    public SetDefaultAddressResponseDTO execute(SetDefaultAddressRequestDTO request) { 
+        
+        var addressId = request.addressId();
+        var userId = request.userId();
+
+        Address targetAddress = repository.findById(addressId)
+            .orElseThrow(() -> new RuntimeException("Address not found"));
+
+        if (!targetAddress.getUserId().equals(userId)) {
+          throw new RuntimeException("Unauthorized");
+        }
+
+        repository.clearDefaultByUserId(userId);
+
+        targetAddress.update(
+            targetAddress.getFullName(),
+            targetAddress.getPhoneNumber().value(), 
+            targetAddress.getAddressLine1(),
+            targetAddress.getAddressLine2(),
+            targetAddress.getSubDistrict(),
+            targetAddress.getDistrict(),
+            targetAddress.getProvince(),
+            targetAddress.getPostalCode(),
+            targetAddress.getCountry(),
+            targetAddress.getLabel(),
+            true
+        );
+
+        repository.save(targetAddress);
+        return new SetDefaultAddressResponseDTO("Address is now set to default");
+    }
+}


### PR DESCRIPTION
พี่หมิงจ้าาาา

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "set default address" feature, introducing a `PATCH /api/addresses/default` endpoint that clears all existing default flags for a user and marks a chosen address as the new default. The overall architecture follows the project's clean layered pattern (controller → use case → repository interface → JPA impl), and the DTOs are well-formed — however, there are two critical bugs that will prevent the application from running correctly.

**Key issues found:**
- **Application will not start** — `SetDefaultAddressUsecase` is missing the `@Service` annotation. Both sibling use cases (`CreateAddressUsecase`, `DeleteAddressUsecase`) have it; without it Spring cannot autowire the bean into `AddressController`.
- **`TransactionRequiredException` at runtime** — The `@Modifying` JPQL query in `JpaAddressRepository.clearDefaultAddressForUser` has no `@Transactional` annotation, which Spring Data JPA requires for all modifying queries.
- **Missing `@Param` binding** — The named JPQL parameter `:userId` is not matched by a `@Param("userId")` annotation on the method argument, which can cause parameter-binding failures depending on compiler settings.
- **Non-atomic clear + save** — `clearDefaultByUserId` and `repository.save` in the use case are not wrapped in a single transaction. A failure between the two steps would leave the user with no default address at all.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge — critical bugs will prevent the application from starting and cause runtime exceptions.
- The missing @Service annotation is a hard blocker: the Spring context will fail to wire AddressController. Even if that were fixed, the @Modifying query without @Transactional will throw at runtime. Both issues must be resolved before this can ship.
- SetDefaultAddressUsecase.java (missing @Service, non-atomic operations) and JpaAddressRepository.java (missing @Transactional and @Param on the new query).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main/java/com/example/restservice/Address/usecases/SetDefaultAddressUsecase.java | Critical issues: missing @Service causes the application to fail to start; missing @Transactional makes the clear+save non-atomic and vulnerable to leaving users with no default address. |
| src/main/java/com/example/restservice/Address/repositories/JpaAddressRepository.java | @Modifying query is missing @Transactional (causes TransactionRequiredException at runtime) and the named parameter :userId is missing the @Param("userId") binding annotation. |
| src/main/java/com/example/restservice/Address/controllers/AddressController.java | New PATCH /default endpoint correctly delegates to SetDefaultAddressUsecase following clean architecture; no issues in the controller itself. |
| src/main/java/com/example/restservice/Address/domain/DatabaseAddressRepository.java | Clean addition of clearDefaultByUserId to the domain repository interface; follows existing conventions. |
| src/main/java/com/example/restservice/Address/repositories/DatabaseAddressRepositoryImpl.java | Correctly delegates clearDefaultByUserId to JpaAddressRepository; straightforward implementation with no issues. |
| src/main/java/com/example/restservice/Address/dto/SetDefaultAddressRequestDTO.java | Clean Java record DTO with proper @NotNull validation constraints for both addressId and userId. |
| src/main/java/com/example/restservice/Address/dto/SetDefaultAddressResponseDTO.java | Minimal, correct response DTO record; no issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant AddressController
    participant SetDefaultAddressUsecase
    participant DatabaseAddressRepository
    participant JpaAddressRepository
    participant DB

    Client->>AddressController: PATCH /api/addresses/default {addressId, userId}
    AddressController->>SetDefaultAddressUsecase: execute(requestDTO)
    SetDefaultAddressUsecase->>DatabaseAddressRepository: findById(addressId)
    DatabaseAddressRepository->>JpaAddressRepository: findById(addressId)
    JpaAddressRepository->>DB: SELECT * FROM addresses WHERE id = ?
    DB-->>JpaAddressRepository: AddressModel
    JpaAddressRepository-->>DatabaseAddressRepository: AddressModel
    DatabaseAddressRepository-->>SetDefaultAddressUsecase: Address (domain)
    Note over SetDefaultAddressUsecase: Verify address.userId == request.userId
    SetDefaultAddressUsecase->>DatabaseAddressRepository: clearDefaultByUserId(userId)
    DatabaseAddressRepository->>JpaAddressRepository: clearDefaultAddressForUser(userId)
    JpaAddressRepository->>DB: UPDATE addresses SET is_default=false WHERE user_id=?
    DB-->>JpaAddressRepository: OK
    SetDefaultAddressUsecase->>SetDefaultAddressUsecase: address.update(..., isDefault=true)
    SetDefaultAddressUsecase->>DatabaseAddressRepository: save(address)
    DatabaseAddressRepository->>JpaAddressRepository: save(AddressModel)
    JpaAddressRepository->>DB: UPDATE addresses SET is_default=true WHERE id=?
    DB-->>JpaAddressRepository: AddressModel
    JpaAddressRepository-->>DatabaseAddressRepository: AddressModel
    DatabaseAddressRepository-->>SetDefaultAddressUsecase: Address
    SetDefaultAddressUsecase-->>AddressController: SetDefaultAddressResponseDTO
    AddressController-->>Client: 200 OK {message}
```

<sub>Last reviewed commit: f3408ab</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - # Code Review Rule: Separation of Concerns by Laye... ([source](https://app.greptile.com/review/custom-context?memory=71de1a33-4d13-4be4-b844-db2b9e14b831))

<!-- /greptile_comment -->