### PR TITLE
feat: Add CategoryId for Product Entities

### DIFF
--- a/src/main/java/com/example/restservice/Products/domain/Price.java
+++ b/src/main/java/com/example/restservice/Products/domain/Price.java
@@ -12,7 +12,6 @@ public final class Price {
 
   private final BigDecimal value;
 
-
   private Price(BigDecimal value) {
     Objects.requireNonNull(value, "Price cannot be null");
 

--- a/src/main/java/com/example/restservice/Products/domain/Product.java
+++ b/src/main/java/com/example/restservice/Products/domain/Product.java
@@ -41,7 +41,7 @@ public class Product {
   }
 
   public static Product create(
-      UUID id, String name, BigDecimal price, String description,UUID categoryId, UUID createdBy) {
+      UUID id, String name, BigDecimal price, String description, UUID categoryId, UUID createdBy) {
 
     return new Product(
         id,
@@ -64,7 +64,8 @@ public class Product {
       LocalDateTime createdAt,
       LocalDateTime updatedAt) {
 
-    return new Product(id, name, Price.of(price), description, createdBy,categoryId, createdAt, updatedAt);
+    return new Product(
+        id, name, Price.of(price), description, createdBy, categoryId, createdAt, updatedAt);
   }
 
   public void update(String name, BigDecimal price, String description) {
@@ -119,8 +120,8 @@ public class Product {
   public LocalDateTime getUpdatedAt() {
     return updatedAt;
   }
-  public UUID getCategoryId(){
+
+  public UUID getCategoryId() {
     return categoryId;
   }
-
 }

--- a/src/main/java/com/example/restservice/Products/dto/CreateProductRequestDTO.java
+++ b/src/main/java/com/example/restservice/Products/dto/CreateProductRequestDTO.java
@@ -17,7 +17,4 @@ public record CreateProductRequestDTO(
     @NotNull(message = "Category ID is required") UUID categoryId,
     @NotNull(message = "Price is required") @Positive(message = "Price must be greater than zero")
         BigDecimal price,
-    @NotNull(message = "Creator User ID is required") UUID createdBy) 
-
-    {}
-
+    @NotNull(message = "Creator User ID is required") UUID createdBy) {}

--- a/src/main/java/com/example/restservice/Products/models/ProductModel.java
+++ b/src/main/java/com/example/restservice/Products/models/ProductModel.java
@@ -66,7 +66,8 @@ public class ProductModel {
   public LocalDateTime getUpdatedAt() {
     return updatedAt;
   }
-  public UUID getCategoryId(){
+
+  public UUID getCategoryId() {
     return categoryId;
   }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `categoryId` field to `Product` entities so that products can be associated with a category. The DTO, use-case, and domain factory signatures are updated correctly, but the persistence layer (`ProductModel`) contains three critical bugs that prevent the feature from working and will corrupt data.

**Key issues found:**

- **`categoryId` never assigned in `Product` constructor** (`Product.java`): The field is accepted as a parameter but `this.categoryId = categoryId` is missing, so every `Product` instance silently carries a `null` category ID regardless of input.
- **Erroneous `@Id` annotation** (`ProductModel.java`, line 29): `categoryId` is annotated with `@Id` alongside the existing `@Id` on `id`. Without an `@IdClass` or `@EmbeddedId`, JPA will either throw a startup exception or create an unintended composite primary key.
- **`categoryId`/`createdBy` swapped in `toDomain()`** (`ProductModel.java`): The arguments are passed in the wrong order to `Product.rehydrate()`, meaning every product loaded from the database will have its `createdBy` populated with a category UUID and vice versa.
- **`fromDomain()` never maps `categoryId`** (`ProductModel.java`): The `categoryId` is not transferred from the domain object to the model on save, so the column will always be `null` in the database.

<h3>Confidence Score: 0/5</h3>

- This PR must not be merged — it contains four critical bugs that will corrupt stored data and likely cause a JPA startup failure.
- Four independent critical defects exist: (1) `categoryId` is never actually stored in the domain object, (2) `@Id` is duplicated on the model without a composite-key declaration, (3) `createdBy` and `categoryId` are silently swapped on every database read, and (4) `categoryId` is never persisted by `fromDomain()`. Any one of these alone would break the feature; together they would corrupt data on both writes and reads.
- `ProductModel.java` requires the most attention (three separate bugs). `Product.java` also needs the missing constructor assignment fixed before this PR is safe to merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/main/java/com/example/restservice/Products/domain/Product.java | Adds `categoryId` field and threads it through `create()`/`rehydrate()` factory methods, but the private constructor never assigns `this.categoryId = categoryId`, so the field is always `null` at runtime. |
| src/main/java/com/example/restservice/Products/models/ProductModel.java | Three separate bugs: `categoryId` is annotated with `@Id` (creating an erroneous composite key), `categoryId`/`createdBy` are swapped in `toDomain()`, and `fromDomain()` never maps `categoryId` from the domain object. |
| src/main/java/com/example/restservice/Products/dto/CreateProductRequestDTO.java | Correctly adds `categoryId` as a `@NotNull`-validated `UUID` field to the request DTO; no issues found. |
| src/main/java/com/example/restservice/Products/usecases/CreateProductUsecase.java | Correctly passes `request.categoryId()` to `Product.create()`; use-case layer itself is clean and follows the clean architecture pattern. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Controller
    participant CreateProductUsecase
    participant Product (domain)
    participant ProductModel
    participant Repository/DB

    Client->>Controller: POST /products (name, price, description, categoryId, createdBy)
    Controller->>CreateProductUsecase: execute(CreateProductRequestDTO)
    CreateProductUsecase->>Product (domain): Product.create(id, name, price, description, categoryId, createdBy)
    Note over Product (domain): ⚠️ categoryId param received but<br/>never assigned (this.categoryId = null)
    Product (domain)-->>CreateProductUsecase: Product instance (categoryId = null)
    CreateProductUsecase->>ProductModel: productRepository.save(product)
    Note over ProductModel: ProductModel.fromDomain(product)<br/>⚠️ categoryId never mapped → null in DB
    ProductModel->>Repository/DB: INSERT (categoryId = null)
    Repository/DB-->>Client: 200 OK "Product was created"

    Note over ProductModel: On READ: toDomain() swaps<br/>createdBy ↔ categoryId arguments
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/main/java/com/example/restservice/Products/domain/Product.java`, line 31-41 ([link](https://github.com/ax-47/java_project/blob/4d62a40edc9fdf341c940664ee0546b9d2a85c7b/src/main/java/com/example/restservice/Products/domain/Product.java#L31-L41)) 

   **`categoryId` accepted but never assigned in constructor**

   `categoryId` is added to the private constructor's parameter list, but `this.categoryId = categoryId` is never written inside the body. As a result, every `Product` instance will always have a `null` `categoryId` regardless of what is passed in, silently discarding the value.


2. `src/main/java/com/example/restservice/Products/models/ProductModel.java`, line 86-103 ([link](https://github.com/ax-47/java_project/blob/4d62a40edc9fdf341c940664ee0546b9d2a85c7b/src/main/java/com/example/restservice/Products/models/ProductModel.java#L86-L103)) 

   **`fromDomain()` never sets `categoryId`**

   `ProductModel.fromDomain()` maps all domain fields to the model, but `categoryId` is missing. When a new product is persisted, `categoryId` will always be `null` in the database row, effectively making the feature a no-op on writes.

   Add the missing mapping:
   ```java
   model.categoryId = product.getCategoryId();
   ```
   after the existing `model.createdBy = product.getCreatedBy();` line.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 4d62a40</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->